### PR TITLE
fix: Increase Sequence number only if it's not a flow.

### DIFF
--- a/src/routes/ViewHelper.ts
+++ b/src/routes/ViewHelper.ts
@@ -64,7 +64,7 @@ export class ViewHelper {
     }
     static calculateDecorations(items) {
         let decors = [];
-        let seq = 1;
+        let seq = 0;
         items.forEach(item => {
             let color = 'red';
             if (item.status == 'end') {
@@ -73,9 +73,9 @@ export class ViewHelper {
                 else
                     color = 'black';
             }
+            if (item.type != 'bpmn:SequenceFlow') seq++;
             let decor = { id: item.elementId, color, seq };
             decors.push(decor);
-            seq++;
         });
         return decors;
     }


### PR DESCRIPTION
So that sequential numbers display sensible consecutive numbers, only increase seq when the item type is not 'bpmn:SequenceFlow'

seq numbers displayed in the instance details page are  non-consecutive because there is no label on 'bpmn:sequenceFlow' elements. This results in 1, 3, 5 being displayed on the labels for items that display the seq number. 

<img width="887" alt="image" src="https://github.com/user-attachments/assets/2fd9c958-48ae-4a8b-a8d5-961b54da60b5" />

This change makes the displayed sequence number consecutive:
<img width="887" alt="image" src="https://github.com/user-attachments/assets/def60a65-d923-4245-ac1c-017f299cd3bb" />


